### PR TITLE
Yield token spot price calculation fixes

### DIFF
--- a/frontend/src/components/Pages/YTC/Executor/TokenResult.tsx
+++ b/frontend/src/components/Pages/YTC/Executor/TokenResult.tsx
@@ -1,6 +1,6 @@
 import { Flex } from "@chakra-ui/react";
 import { shortenNumber } from "../../../../utils/shortenNumber";
-import { BaseTokenPriceTag } from "../../../Prices";
+import { BaseTokenPriceTag, YTPriceTag } from "../../../Prices";
 
 interface TokenResultProps {
     token: {
@@ -84,13 +84,13 @@ export const TokenResult: React.FC<TokenResultProps> = (props) => {
                             />
                     }
                     {
-                        tokenType === "YToken" && <></>
+                        tokenType === "YToken" &&
                             // This is commented out due to a bug in yt price calculation
-                            // && <YTPriceTag
-                            //     amount={token.amount}
-                            //     baseTokenName={props.baseTokenName}
-                            //     trancheAddress={props.trancheAddress}
-                            // />
+                            <YTPriceTag
+                                amount={token.amount}
+                                baseTokenName={props.baseTokenName}
+                                trancheAddress={props.trancheAddress}
+                            />
                     }
                 </Flex>
             </Flex>

--- a/frontend/src/components/Pages/YTC/Executor/index.tsx
+++ b/frontend/src/components/Pages/YTC/Executor/index.tsx
@@ -15,6 +15,7 @@ import { DetailItem } from '../../../Reusable/DetailItem';
 import { TokenResult } from "./TokenResult";
 import { DetailPane } from "../../../Reusable/DetailPane";
 import WalletSettings from "../../../Wallet/Settings";
+import { BaseTokenPriceTag, YTPriceTag } from "../../../Prices";
 
 export interface ApeProps {
     baseToken: {
@@ -167,6 +168,8 @@ export const Ape: React.FC<ApeProps> = (props: ApeProps) => {
                         apr={gain?.apr}
                         minimumReceived={minimumReturn}
                         expectedReturn={gain?.estimatedRedemption}
+                        trancheAddress={userData.trancheAddress}
+                        baseTokenName={baseToken.name}
                     />
                 </Flex>
             </Card>
@@ -190,6 +193,8 @@ export const Ape: React.FC<ApeProps> = (props: ApeProps) => {
 
 
 interface ExecutionDetailsProps {
+    trancheAddress: string,
+    baseTokenName: string,
     slippageTolerance: number,
     minimumReceived: number,
     expectedReturn?: number,
@@ -200,10 +205,20 @@ interface ExecutionDetailsProps {
 }
 
 const ExecutionDetails: React.FC<ExecutionDetailsProps> = (props) => {
-    const {slippageTolerance, minimumReceived, estimatedGas, netGain, roi, apr, expectedReturn} = props;
+    const {
+        slippageTolerance,
+        minimumReceived,
+        estimatedGas,
+        netGain,
+        roi,
+        apr,
+        expectedReturn,
+        baseTokenName,
+        trancheAddress
+    } = props;
 
     return <DetailPane
-        mx={10}
+        mx={{base: 0, sm: 10}}
     >
         <DetailItem
             name={
@@ -218,24 +233,63 @@ const ExecutionDetails: React.FC<ExecutionDetailsProps> = (props) => {
         />
         <DetailItem
             name="Minimum YT Received:"
-            value={shortenNumber(minimumReceived)}
+            value={
+                <Flex flexDir="row" gridGap={1}>
+                    <Text>
+                        {shortenNumber(minimumReceived)}
+                    </Text>
+                    (<YTPriceTag
+                        amount={expectedReturn}
+                        baseTokenName={baseTokenName}
+                        trancheAddress={trancheAddress}
+                    />)
+                </Flex>
+            }
         />
         <DetailItem
             name="Expected Redemption:"
-            value={expectedReturn ? `$${shortenNumber(expectedReturn)}`: "?"}
+            value={expectedReturn ? 
+                <Flex flexDir="row" gridGap={1}>
+                    <Text>
+                        {shortenNumber(expectedReturn)}
+                    </Text>
+                    (<BaseTokenPriceTag
+                        amount={expectedReturn}
+                        baseTokenName={baseTokenName}
+                    />)
+                </Flex> : <Text>?</Text>
+            }
         />
         <DetailItem
             name="Estimated Gas Cost:"
-            value={`${shortenNumber(estimatedGas)} ETH`}
+            value={
+                <Flex flexDir="row" gridGap={1}>
+                    <Text>
+                        {shortenNumber(estimatedGas)} ETH
+                    </Text>
+                    (<BaseTokenPriceTag
+                        amount={estimatedGas}
+                        baseTokenName={"eth"}
+                    />)
+                </Flex>
+            }
         />
         <DetailItem
             name="Expected Earned:"
             value={netGain ? 
-                <Text
+                <Flex
+                    flexDir="row"
+                    gridGap={1}
                     color={(netGain > 0 ? "green.600" : "red.500")}
                 >
-                    ${shortenNumber(netGain)}
-                </Text> : "?"
+                    <Text>
+                        {shortenNumber(netGain)}
+                    </Text>
+                    (<BaseTokenPriceTag
+                        amount={netGain}
+                        baseTokenName={baseTokenName}
+                    />)
+                </Flex> : "?"
             }
         />
         <DetailItem

--- a/frontend/src/components/Prices/index.tsx
+++ b/frontend/src/components/Prices/index.tsx
@@ -61,9 +61,9 @@ export const YTPriceTag: React.FC<YTPriceTagProps> = (props) => {
 
 
     return (
-        <PriceTag
-            price={price}
-            amount={amount}
+        <BaseTokenPriceTag
+            amount={price}
+            baseTokenName={baseTokenName}
         />
     )
 }

--- a/frontend/src/components/Reusable/DetailItem.tsx
+++ b/frontend/src/components/Reusable/DetailItem.tsx
@@ -1,4 +1,4 @@
-import { Text } from '@chakra-ui/layout';
+import { Flex, Text } from '@chakra-ui/layout';
 
 interface DetailItemProps {
     name: string | React.ReactElement,
@@ -8,8 +8,13 @@ interface DetailItemProps {
 export const DetailItem: React.FC<DetailItemProps> = (props) => {
     const {name, value} = props;
 
-    return <div className="flex flex-row justify-between gap-4">
+    return <Flex 
+        flexDir="row"
+        justify="space-between"
+        gridGap={4}
+        alignItems="center"
+    >
         <Text>{name}</Text>
         <Text>{value}</Text>
-    </div>
+    </Flex>
 }

--- a/frontend/src/components/Reusable/DetailPane.tsx
+++ b/frontend/src/components/Reusable/DetailPane.tsx
@@ -5,6 +5,7 @@ export const DetailPane: React.FC<FlexProps> = (props) => {
     return <Flex
         p={2}
         mx={5}
+        gridGap={1}
         flexDir="column"
         bgColor="light_card"
         {...props}


### PR DESCRIPTION
The same issue with getReserves that was resolved for principal tokens, is now resolved for yield tokens

This PR also includes a few style changes to the executor details pane using this price feed.