### PR TITLE
YT Price tag to show value rather than price

### DIFF
--- a/frontend/src/components/Prices/index.tsx
+++ b/frontend/src/components/Prices/index.tsx
@@ -45,7 +45,7 @@ interface YTPriceTagProps {
 }
 
 export const YTPriceTag: React.FC<YTPriceTagProps> = (props) => {
-    const {baseTokenName, trancheAddress} = props;
+    const {baseTokenName, trancheAddress, amount} = props;
 
     const [price, setPrice] = useState<number>(0);
     const [signer] = useContext(SignerContext);
@@ -62,7 +62,7 @@ export const YTPriceTag: React.FC<YTPriceTagProps> = (props) => {
 
     return (
         <BaseTokenPriceTag
-            amount={price}
+            amount={amount ? price * amount : undefined}
             baseTokenName={baseTokenName}
         />
     )


### PR DESCRIPTION
Price tag was only showing the price of the YTs up until now.

This was swapped to show the value. (value = amount * price)