### PR TITLE
Make info tooltips smaller

### DIFF
--- a/frontend/src/components/Pages/YTC/Calculator/Advanced/index.tsx
+++ b/frontend/src/components/Pages/YTC/Calculator/Advanced/index.tsx
@@ -18,7 +18,7 @@ export const AdvancedCollapsable: React.FC = () => {
         <Button variant="link" onClick={handleToggle} gridGap={2}>
             {show ? <ChevronDownIcon/> : <ChevronRightIcon/>}
             {show ? "Hide" : "Show"} Advanced Options
-            <InfoTooltip label={copy.tooltips.advanced_options}/>
+            <InfoTooltip label={copy.tooltips.advanced_options} h={3} w={3}/>
         </Button>
         <Collapse in={show} >
             <FormLabel

--- a/frontend/src/components/Pages/YTC/Calculator/index.tsx
+++ b/frontend/src/components/Pages/YTC/Calculator/index.tsx
@@ -297,7 +297,7 @@ const Form: React.FC<FormProps> = (props) => {
                         gridGap={2}
                     >
                         Term
-                        <InfoTooltip label={copy.tooltips.term}/>
+                        <InfoTooltip label={copy.tooltips.term} w={3} h={3}/>
                     </Flex>
                 </FormLabel>
                 <Flex
@@ -368,7 +368,7 @@ const Form: React.FC<FormProps> = (props) => {
                         gridGap={2}
                     >
                         Input Amount
-                        <InfoTooltip label={copy.tooltips.input_amount}/>
+                        <InfoTooltip label={copy.tooltips.input_amount} h={3} w={3}/>
                     </Flex>
                 </FormLabel>
                 <Flex

--- a/frontend/src/components/Pages/YTC/Executor/index.tsx
+++ b/frontend/src/components/Pages/YTC/Executor/index.tsx
@@ -257,6 +257,8 @@ const ExecutionDetails: React.FC<ExecutionDetailsProps> = (props) => {
                     </Text>
                     <InfoTooltip
                         label={copy.tooltips.estimated_gain_detail}
+                        w={2}
+                        h={2}
                     />
                 </Flex>
             }
@@ -283,6 +285,8 @@ const ExecutionDetails: React.FC<ExecutionDetailsProps> = (props) => {
                         Return on Investment
                     </Text>
                     <InfoTooltip
+                        w={2}
+                        h={2}
                         label={copy.tooltips.roi}
                     />
                 </Flex>
@@ -302,6 +306,8 @@ const ExecutionDetails: React.FC<ExecutionDetailsProps> = (props) => {
                         APR
                     </Text>
                     <InfoTooltip
+                        w={2}
+                        h={2}
                         label={copy.tooltips.apr}
                     />
                 </Flex>
@@ -326,6 +332,8 @@ const ExecutionDetails: React.FC<ExecutionDetailsProps> = (props) => {
                             Minimum YT Received
                         </Text>
                         <InfoTooltip
+                            w={2}
+                            h={2}
                             label={copy.tooltips.minimum_yt_received}
                         />
                     </Flex>
@@ -350,6 +358,8 @@ const ExecutionDetails: React.FC<ExecutionDetailsProps> = (props) => {
                             Estimated Redemption
                         </Text>
                         <InfoTooltip
+                            w={2}
+                            h={2}
                             label={copy.tooltips.estimated_redemption}
                         />
                     </Flex>
@@ -373,6 +383,8 @@ const ExecutionDetails: React.FC<ExecutionDetailsProps> = (props) => {
                             Minimum Redemption
                         </Text>
                         <InfoTooltip
+                            w={2}
+                            h={2}
                             label={copy.tooltips.minimum_redemption}
                         />
                     </Flex>

--- a/frontend/src/components/Pages/YTC/Table/index.tsx
+++ b/frontend/src/components/Pages/YTC/Table/index.tsx
@@ -70,7 +70,7 @@ const ResultsTable: React.FC<TableProps> = (props) => {
                             gridGap={2}
                         >
                             Estimated Variable Rate
-                            <InfoTooltip label={copy.tooltips.estimated_variable_rate}/>
+                            <InfoTooltip label={copy.tooltips.estimated_variable_rate} h={3} w={3}/>
                         </Flex>
                     </FormLabel>
                     <InputGroup
@@ -109,7 +109,7 @@ const ResultsTable: React.FC<TableProps> = (props) => {
                         gridGap={2}
                     >
                         Number of Compounds
-                        <InfoTooltip label={copy.tooltips.number_of_compounds}/>
+                        <InfoTooltip label={copy.tooltips.number_of_compounds} w={3} h={3}/>
                     </Flex>
                 </FormLabel>
                 <Table

--- a/frontend/src/components/Reusable/Tooltip.tsx
+++ b/frontend/src/components/Reusable/Tooltip.tsx
@@ -1,18 +1,19 @@
 import { InfoOutlineIcon } from '@chakra-ui/icons';
-import { Tooltip } from "@chakra-ui/react";
+import { IconProps, Tooltip } from "@chakra-ui/react";
 
 interface InfoTooltipProps {
     label: string;
 }
 
-export const InfoTooltip: React.FC<InfoTooltipProps> = (props) => {
-    const {label} = props;
+export const InfoTooltip: React.FC<InfoTooltipProps & IconProps> = (props) => {
+    const {label, ...rest} = props;
 
     return <Tooltip label={label}>
         <InfoOutlineIcon
             _hover={{
                 color: "component.blue"
             }}
+            {...rest}
         />
     </Tooltip>
 }


### PR DESCRIPTION
Tooltip icons were taking up extra screen realestate, they have been reduced in size.