### PR TITLE
Balance will show 0 instead of loading

### DIFF
--- a/frontend/src/components/Pages/YTC/Calculator/index.tsx
+++ b/frontend/src/components/Pages/YTC/Calculator/index.tsx
@@ -418,7 +418,7 @@ const Form: React.FC<FormProps> = (props) => {
                         <Box
                             id="balance"
                         >
-                            Balance: {balance ? balance : <Spinner/>}
+                            Balance: {(balance !== undefined) ? balance : <Spinner/>}
                         </Box>
                     </Flex>
                 </Flex>


### PR DESCRIPTION
Quick fix where 0 balance was showing a spinner rather than the number 0